### PR TITLE
Group by author and support `git log` params

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ Estimate time spent on a git repository.
       -h, --help	output usage information
       --max	    	maximum time diff in minutes between two consecultive commits. Default: 90
       --min	    	minimum time in minutes for the start commit. Default: 25
-    
-    any other param will be appended to the git log command.
-      git-time --author=jane.doe@example.com will work
+      --author      filter out authors. Value(s) are passed to the git log command.
       
       
 ## Output

--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ Estimate time spent on a git repository.
       -h, --help	output usage information
       --max	    	maximum time diff in minutes between two consecultive commits. Default: 90
       --min	    	minimum time in minutes for the start commit. Default: 25
+    
+    any other param will be appended to the git log command.
+      git-time --author=jane.doe@example.com will work
+      
+      
+## Output
+
+Output is grouped by author
+```
+John Doe <john.doe@example.com>
+102 commits found
+Total time spent: 103.84 hours
+
+Jane Doe <jane.doe@example.com>
+321 commits found
+Total time spent: 183.11 hours
+```

--- a/bin/git-time.js
+++ b/bin/git-time.js
@@ -31,13 +31,23 @@ if (typeof argv.max === 'number') {
 }
 max *= 60
 
+// all non common arguments will be passed to the `git log` command
+var gitArgs = process.argv
+  .slice(3) // get the args after path
+  .filter(argumentString => // remove common args
+    ['--max', '--min', '--help'].reduce(
+      (notThere, prefix) => notThere && argumentString.indexOf(prefix) !== 0,
+      true
+    )
+  ).join(" ");
+
 exec(`ls ${dir}/.git`, function (err, data) {
   if (err) {
     console.log(`${dir} is not a valid Git directory`)
     return
   }
 
-  exec(`cd ${dir} && git log --pretty='format:%ct'`, function (err, data) {
+  exec(`cd ${dir} && git log ${gitArgs} --pretty='format:%ct'`, function (err, data) {
     if (err) {
       console.log(err)
       return

--- a/bin/git-time.js
+++ b/bin/git-time.js
@@ -8,8 +8,7 @@ if (typeof argv.help == 'boolean' || typeof argv.h == 'boolean' || typeof argv._
   console.log('  -h, --help\toutput usage information')
   console.log('  --max\t\tmaximum time in minutes between two consecultive commits. Default: 90')
   console.log('  --min\t\tminimum time in minutes for the start commit. Default: 25')
-  console.log('any other param will be appended to the git log command.')
-  console.log('  git-time --author=jane.doe@example.com will work')
+  console.log('  --author\t\tfilter out authors. Value(s) are passed to the git log command.')
   
   return;
 }
@@ -34,15 +33,14 @@ if (typeof argv.max === 'number') {
 }
 max *= 60
 
-// all non common arguments will be passed to the `git log` command
-var gitArgs = process.argv
-  .slice(3) // get the args after path
-  .filter(argumentString => // remove common args
-    ['--max', '--min', '--help'].reduce(
-      (notThere, prefix) => notThere && argumentString.indexOf(prefix) !== 0,
-      true
-    )
-  ).join(" ");
+var authors = [];
+if (argv.author) {
+  if(typeof argv.author.map === 'function') {
+    authors = argv.author;
+  } else {
+    authors = [argv.author];
+  }
+}
 
 exec(`ls ${dir}/.git`, function (err, data) {
   if (err) {
@@ -50,7 +48,7 @@ exec(`ls ${dir}/.git`, function (err, data) {
     return
   }
 
-  exec(`cd ${dir} && git log ${gitArgs} --pretty='format:%an <%ae> %ct'`, function (err, data) {
+  exec(`cd ${dir} && git log ${authors.map(author => `--author="${author}"`).join(" ")} --pretty='format:%an <%ae> %ct'`, function (err, data) {
     if (err) {
       console.log(err)
       return

--- a/bin/git-time.js
+++ b/bin/git-time.js
@@ -8,6 +8,9 @@ if (typeof argv.help == 'boolean' || typeof argv.h == 'boolean' || typeof argv._
   console.log('  -h, --help\toutput usage information')
   console.log('  --max\t\tmaximum time in minutes between two consecultive commits. Default: 90')
   console.log('  --min\t\tminimum time in minutes for the start commit. Default: 25')
+  console.log('any other param will be appended to the git log command.')
+  console.log('  git-time --author=jane.doe@example.com will work')
+  
   return;
 }
 


### PR DESCRIPTION
1. Pass non common args to `git log` command
This way you can use the `--author` or any other argument to filter the state

2. Group by distinct authors
get an output for each author :
```
John Doe <john.doe@example.com>
102 commits found
Total time spent: 103.84 hours

Jane Doe <jane.doe@example.com>
321 commits found
Total time spent: 183.11 hours
```