### PR TITLE
Windows Compatibility

### DIFF
--- a/bin/git-time.js
+++ b/bin/git-time.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var argv = require('minimist')(process.argv.slice(2));
+var os = require('os');
 
 // If help or bad usage
 if (typeof argv.help == 'boolean' || typeof argv.h == 'boolean' || typeof argv._[0] == 'undefined') {
@@ -42,13 +43,20 @@ if (argv.author) {
   }
 }
 
-exec(`ls ${dir}/.git`, function (err, data) {
+
+var lsCommand = `ls ${dir}/.git`;
+
+if(os.platform() === 'win32'){
+	lsCommand = `dir ${dir}\\.git`;
+}
+
+exec(lsCommand, function (err, data) {
   if (err) {
     console.log(`${dir} is not a valid Git directory`)
     return
   }
 
-  exec(`cd ${dir} && git log ${authors.map(author => `--author="${author}"`).join(" ")} --pretty='format:%an <%ae> %ct'`, function (err, data) {
+  exec(`cd ${dir} && git log ${authors.map(author => `--author="${author}"`).join(" ")} --pretty="%an <%ae> %ct"`, function (err, data) {
     if (err) {
       console.log(err)
       return

--- a/bin/git-time.js
+++ b/bin/git-time.js
@@ -43,6 +43,8 @@ if (argv.author) {
   }
 }
 
+// Wrap in quotes to escape spaces
+dir = '"' + dir + '"'
 
 var lsCommand = `ls ${dir}/.git`;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "git-time",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,8 +14,8 @@
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-2.1.1.tgz",
       "integrity": "sha512-TSJw3LY9ZRSis7yYzQ7flIdtQMbacd9oYoiFphJhI4SzgmqF0zErO+uNv0lbUjk1L4AGfHQJ4OVYYzW+JV66KA==",
       "requires": {
-        "colors": "1.3.3",
-        "string-width": "2.1.1"
+        "colors": "^1.1.2",
+        "string-width": "^2.1.1"
       }
     },
     "colors": {
@@ -38,8 +38,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "strip-ansi": {
@@ -47,7 +47,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "git-time",
-  "version": "1.0.6",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,8 +14,8 @@
       "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-2.1.1.tgz",
       "integrity": "sha512-TSJw3LY9ZRSis7yYzQ7flIdtQMbacd9oYoiFphJhI4SzgmqF0zErO+uNv0lbUjk1L4AGfHQJ4OVYYzW+JV66KA==",
       "requires": {
-        "colors": "^1.1.2",
-        "string-width": "^2.1.1"
+        "colors": "1.3.3",
+        "string-width": "2.1.1"
       }
     },
     "colors": {
@@ -38,8 +38,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "strip-ansi": {
@@ -47,7 +47,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Measure time spent on a git repository",
   "homepage": "https://github.com/vmf91/git-time#readme",
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/vmf91/git-time"
+    "type": "git",
+    "url": "https://github.com/vmf91/git-time"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To add Windows compatibility:
 - `dir` is used instead of `ls` if the operating system is Windows.
 - `format:` was removed from `git log --pretty` as it caused issues on Windows, and was not required for linux (at least from my brief testing).

Additionally, the directory string is wrapped in quotes to allow for spaces